### PR TITLE
Delete <s-g> keymap

### DIFF
--- a/plugin/skkeleton-azik.vim
+++ b/plugin/skkeleton-azik.vim
@@ -32,7 +32,6 @@ call skkeleton#register_kanatable('rom',{
   \ '<c-l>': 'disable',
   \ '<s-l>': 'zenkaku',
   \ '<s-q>': 'katakana',
-  \ '<s-g>': 'deleteChar',
   \ })
 
 call skkeleton#register_kanatable('rom',{


### PR DESCRIPTION
Shift key must be used for type some words starting with が行.